### PR TITLE
Introduced MainViewModel to handle UI logic outside of activity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,4 +42,7 @@ dependencies {
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+
+    implementation "androidx.fragment:fragment-ktx:1.2.5"
+
 }

--- a/app/src/main/java/com/sample/randomquote/MainViewModel.kt
+++ b/app/src/main/java/com/sample/randomquote/MainViewModel.kt
@@ -1,0 +1,36 @@
+package com.sample.randomquote
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import java.util.concurrent.Executors
+
+class MainViewModel : ViewModel() {
+
+    private val _loading = MutableLiveData<Boolean>()
+    val loading: LiveData<Boolean> = _loading
+    private val _quote = MutableLiveData<Quote>()
+    val quote: LiveData<Quote> = _quote
+
+    fun refreshQuote() {
+        val quoteGenerator = QuoteGenerator()
+
+        _loading.postValue(true)
+
+        Executors.defaultThreadFactory().newThread {
+            quoteGenerator.getRandomQuote(object : QuoteCallback {
+                override fun onSuccess(quote: Quote) {
+                    _loading.postValue(false)
+                    _quote.postValue(quote)
+                }
+
+                override fun onFailure(error: Throwable) {
+                    _loading.postValue(false)
+
+                    error.printStackTrace()
+                }
+            })
+        }.start()
+    }
+
+}


### PR DESCRIPTION
The MainActivity is responsible for
- displaying quotes to the user
- reacting to refresh button clicks

MainViewModel now handles the UI logic which includes:
- notifying the activity when loading a quote
- notifiying the activity when the quote is ready to be displayed.
- Using a separate thread to prevent blocking the UI thread

Because MainViewModel out lives the state of MainActivity, our activity can now handle configuration changes (rotating the screen) for free.