### PR TITLE
Handle system initiated process death with SaveStateHandle

### DIFF
--- a/app/src/main/java/com/sample/randomquote/MainActivity.kt
+++ b/app/src/main/java/com/sample/randomquote/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.sample.randomquote
 
 import android.os.Bundle
+import android.os.PersistableBundle
 import android.view.View
 import android.widget.Button
 import android.widget.TextView
@@ -21,8 +22,7 @@ class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
 
         initUi()
-        if (savedInstanceState == null)
-            viewModel.refreshQuote()
+        viewModel.refreshQuote()
     }
 
     private fun initUi() {
@@ -44,5 +44,10 @@ class MainActivity : AppCompatActivity() {
             progressBar.visibility = if (loading) View.VISIBLE else View.INVISIBLE
             refreshButton.isEnabled = !loading
         })
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        viewModel.saveState()
+        super.onSaveInstanceState(outState)
     }
 }

--- a/app/src/main/java/com/sample/randomquote/MainViewModel.kt
+++ b/app/src/main/java/com/sample/randomquote/MainViewModel.kt
@@ -2,10 +2,11 @@ package com.sample.randomquote
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import java.util.concurrent.Executors
 
-class MainViewModel : ViewModel() {
+class MainViewModel(val savedStateHandle: SavedStateHandle) : ViewModel() {
 
     private val _loading = MutableLiveData<Boolean>()
     val loading: LiveData<Boolean> = _loading
@@ -13,24 +14,56 @@ class MainViewModel : ViewModel() {
     val quote: LiveData<Quote> = _quote
 
     fun refreshQuote() {
-        val quoteGenerator = QuoteGenerator()
+        if (!loadState()) {
+            val quoteGenerator = QuoteGenerator()
 
-        _loading.postValue(true)
+            _loading.postValue(true)
 
-        Executors.defaultThreadFactory().newThread {
-            quoteGenerator.getRandomQuote(object : QuoteCallback {
-                override fun onSuccess(quote: Quote) {
-                    _loading.postValue(false)
-                    _quote.postValue(quote)
-                }
+            Executors.defaultThreadFactory().newThread {
+                quoteGenerator.getRandomQuote(object : QuoteCallback {
+                    override fun onSuccess(quote: Quote) {
+                        _loading.postValue(false)
+                        _quote.postValue(quote)
+                    }
 
-                override fun onFailure(error: Throwable) {
-                    _loading.postValue(false)
+                    override fun onFailure(error: Throwable) {
+                        _loading.postValue(false)
 
-                    error.printStackTrace()
-                }
-            })
-        }.start()
+                        error.printStackTrace()
+                    }
+                })
+            }.start()
+        }
     }
 
+    /**
+     * Loads the state of the app before activity was reconfigured or destroyed
+     *
+     * @return: True if the state was loaded. False if the application was not loaded from a
+     * previous state
+     */
+    private fun loadState(): Boolean {
+        if (!savedStateHandle.contains(QUOTE) && !savedStateHandle.contains(QUOTE_AUTHOR)){
+            return false
+        }
+
+        val quote = Quote(
+            author = savedStateHandle.get<String>(QUOTE_AUTHOR) ?: "",
+            quote = savedStateHandle.get<String>(QUOTE) ?: ""
+        )
+        savedStateHandle.remove<String>(QUOTE)
+        savedStateHandle.remove<String>(QUOTE_AUTHOR)
+        _quote.postValue(quote)
+        return true
+    }
+
+    fun saveState() {
+        savedStateHandle.set(QUOTE_AUTHOR, _quote.value?.author)
+        savedStateHandle.set(QUOTE, _quote.value?.quote)
+    }
+
+    companion object {
+        const val QUOTE = "quote"
+        const val QUOTE_AUTHOR = "quote_author"
+    }
 }


### PR DESCRIPTION
ViewModel handles configuration changes, however, system process deaths are not. To ensure a seamless experience for users, we load the state of the activity after it's destroyed by the system using SavedStateHandle.