### PR TITLE
Added rating to QuoteEntity

### DIFF
--- a/app/src/main/java/com/sample/randomquote/QuoteRepository.kt
+++ b/app/src/main/java/com/sample/randomquote/QuoteRepository.kt
@@ -26,7 +26,8 @@ class QuoteRepository(
                             QuoteEntity(
                                 id = it.id,
                                 author = it.author,
-                                quote = it.quote
+                                quote = it.quote,
+                                rating = it.rating
                             )
                         }.toTypedArray()
                     )

--- a/app/src/main/java/com/sample/randomquote/database/QuoteDatabase.kt
+++ b/app/src/main/java/com/sample/randomquote/database/QuoteDatabase.kt
@@ -3,7 +3,7 @@ package com.sample.randomquote.database
 import androidx.room.Database
 import androidx.room.RoomDatabase
 
-@Database(entities = [QuoteEntity::class], version = 1)
+@Database(entities = [QuoteEntity::class], version = 2)
 abstract class QuoteDatabase : RoomDatabase() {
     abstract fun quoteDao(): QuoteDao
 }

--- a/app/src/main/java/com/sample/randomquote/database/QuoteEntity.kt
+++ b/app/src/main/java/com/sample/randomquote/database/QuoteEntity.kt
@@ -1,5 +1,6 @@
 package com.sample.randomquote.database
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.sample.randomquote.database.QuoteEntity.Companion.TABLE_NAME
@@ -10,7 +11,9 @@ data class QuoteEntity(
     @PrimaryKey
     val id: String = UUID.randomUUID().toString(),
     val quote: String,
-    val author: String
+    val author: String,
+    @ColumnInfo(defaultValue = "null")
+    val rating: Double? = null
 ) {
     companion object {
         const val TABLE_NAME = "quote"


### PR DESCRIPTION
A quote can now have a an optional rating.
In our database migration we set the rating to null as a default value. @ColumnInfo(defaultValue = "null") ensures that users who install the app after schema version 2 have the same schema as users migrating from version 1.
https://developer.android.com/training/data-storage/room/migrating-db-versions.md#handle-default-values-migrations